### PR TITLE
Active quests view

### DIFF
--- a/lib/model/game_state.dart
+++ b/lib/model/game_state.dart
@@ -1,6 +1,7 @@
 import 'dart:math';
 
 import 'package:flutter/foundation.dart';
+import 'package:treasure_of_the_high_seas/model/card/card_types.dart';
 import 'package:treasure_of_the_high_seas/model/resource.dart';
 import 'package:treasure_of_the_high_seas/model/scry_option.dart';
 import 'package:treasure_of_the_high_seas/model/special_triggers.dart';
@@ -78,6 +79,12 @@ class GameState with ChangeNotifier {
     currentCard = null;
 
     notifyListeners();
+  }
+
+  List<Card> getActiveQuestCards() {
+    final discardQuestCards = discard.reversed.where((card) => card.type == CardType.QUEST).toList();
+    final deckQuestCards = deck.reversed.where((card) => card.type == CardType.QUEST).toList();
+    return discardQuestCards + deckQuestCards;
   }
 
   void endGame(GameResult result) {

--- a/lib/model/game_state.dart
+++ b/lib/model/game_state.dart
@@ -82,10 +82,8 @@ class GameState with ChangeNotifier {
   }
 
   List<Card> getActiveQuestCards() {
-    final discardQuestCards = discard.where((card) => card.type == CardType.QUEST).toList();
-    final deckQuestCards = deck.where((card) => card.type == CardType.QUEST).toList();
-    final currentQuestCard = [currentCard].where((card) => card.type == CardType.QUEST).toList();
-    return discardQuestCards + deckQuestCards + currentQuestCard;
+    final cardsToSearch = discard + deck + [currentCard];
+    return cardsToSearch.where((card) => card.type == CardType.QUEST).toList();
   }
 
   void endGame(GameResult result) {

--- a/lib/model/game_state.dart
+++ b/lib/model/game_state.dart
@@ -82,8 +82,8 @@ class GameState with ChangeNotifier {
   }
 
   List<Card> getActiveQuestCards() {
-    final discardQuestCards = discard.reversed.where((card) => card.type == CardType.QUEST).toList();
-    final deckQuestCards = deck.reversed.where((card) => card.type == CardType.QUEST).toList();
+    final discardQuestCards = discard.where((card) => card.type == CardType.QUEST).toList();
+    final deckQuestCards = deck.where((card) => card.type == CardType.QUEST).toList();
     return discardQuestCards + deckQuestCards;
   }
 

--- a/lib/model/game_state.dart
+++ b/lib/model/game_state.dart
@@ -84,7 +84,8 @@ class GameState with ChangeNotifier {
   List<Card> getActiveQuestCards() {
     final discardQuestCards = discard.where((card) => card.type == CardType.QUEST).toList();
     final deckQuestCards = deck.where((card) => card.type == CardType.QUEST).toList();
-    return discardQuestCards + deckQuestCards;
+    final currentQuestCard = [currentCard].where((card) => card.type == CardType.QUEST).toList();
+    return discardQuestCards + deckQuestCards + currentQuestCard;
   }
 
   void endGame(GameResult result) {

--- a/lib/screens/play/play_page.dart
+++ b/lib/screens/play/play_page.dart
@@ -11,6 +11,7 @@ import '../settings_page.dart';
 import './player_hand.dart';
 import 'card/card_display.dart';
 import 'card/deck_state_panel.dart';
+import 'view_active_quests_page.dart';
 
 class PlayPage extends StatelessWidget {
   PlayPage(this.title, this.state, {Key key}) : super(key: key);
@@ -35,6 +36,16 @@ class PlayPage extends StatelessWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(builder: (context) => QuickRulesPage()),
+                    );
+                  },
+                ),
+                IconButton(
+                  icon: Icon(Icons.assignment),
+                  tooltip: 'Active Quests',
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(builder: (context) => ViewActiveQuestsPage(state)),
                     );
                   },
                 ),

--- a/lib/screens/play/view_active_quests_page.dart
+++ b/lib/screens/play/view_active_quests_page.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:treasure_of_the_high_seas/model/game_state.dart';
+import 'card_viewer.dart';
+
+class ViewActiveQuestsPage extends StatelessWidget {
+  final GameState state;
+
+  const ViewActiveQuestsPage(this.state);
+  @override
+  Widget build(BuildContext context) {
+    final activeQuests = state.getActiveQuestCards();
+
+    return Scaffold(
+        appBar: AppBar(
+          title: Text('Active Quests'),
+        ),
+        body: ChangeNotifierProvider.value(
+            value: state,
+            child: Consumer<GameState>(builder: (context, state, _) {
+              return Column(children: <Widget>[
+                Expanded(child: CardViewer(activeQuests, buttons)),
+                Container(
+                    padding: EdgeInsets.symmetric(vertical: 5),
+                    width: MediaQuery.of(context).size.width * 0.7,
+                    child: RaisedButton(
+                      shape: RoundedRectangleBorder(
+                        side: BorderSide(color: Colors.black, width: 1),
+                        borderRadius: BorderRadius.circular(10),
+                      ),
+                      onPressed: () {
+                        Navigator.of(context).pop();
+                      },
+                      color: Colors.green,
+                      child: Text("Close", style: TextStyle(fontSize: 30)),
+                    ))
+              ]);
+            })));
+  }
+
+  List<Widget> buttons(context, card) {
+    return [];
+  }
+}

--- a/test/model/game_state_test.dart
+++ b/test/model/game_state_test.dart
@@ -1,9 +1,14 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:matcher/matcher.dart' as matcher;
 import 'package:mockito/mockito.dart';
+import 'package:treasure_of_the_high_seas/model/card/basic/a_game_of_cards.dart';
 import 'package:treasure_of_the_high_seas/model/card/basic/a_rival_ship.dart';
 import 'package:treasure_of_the_high_seas/model/card/basic/plunder_a_wreck.dart';
 import 'package:treasure_of_the_high_seas/model/card/basic/port_fees.dart';
+import 'package:treasure_of_the_high_seas/model/card/quest/hispaniola_2_land_ahoy.dart';
+import 'package:treasure_of_the_high_seas/model/card/quest/into_the_depths_1_a_sense_of_porpoise.dart';
+import 'package:treasure_of_the_high_seas/model/card/quest/into_the_depths_2_shoally_you_cant_be_serious.dart';
+import 'package:treasure_of_the_high_seas/model/card/quest/into_the_depths_3_kraken_in_my_boots.dart';
 import 'package:treasure_of_the_high_seas/model/card/special/special_cards.dart';
 import 'package:treasure_of_the_high_seas/model/game_result.dart';
 import 'package:treasure_of_the_high_seas/model/game_state.dart';
@@ -213,7 +218,6 @@ void main() {
     });
   });
 
-
   group('ChangeNotifier', () {
     _verifyChangeNotifier(GameState state, Function() stateFunction) {
       final fn = MockFunction().fn;
@@ -232,6 +236,23 @@ void main() {
       _verifyChangeNotifier(state, () => state.replaceScryedCard(PlunderAWreck(), ScryOption.TOP));
       _verifyChangeNotifier(state, state.exileCurrentCard);
       _verifyChangeNotifier(state, () => state.endGame(GameResult.WIN));
+    });
+  });
+
+  group('Getting active quests', () {
+    test('should return only quest cards from the deck and discard pile in reverse order', () {
+      const aGameOfCards = AGameOfCards(); // basic card
+      const aRivalShip = ARivalShip(); // basic card
+      const landAhoy = LandAhoy(); // quest card
+      const aSenseOfPorpoise = ASenseOfPorpoise(); // quest card
+      const krakenInMyBoots = KrakenInMyBoots(); // quest card
+      const shoallyYouCantBeSerious = ShoallyYouCantBeSerious(); // quest card
+      final GameState state = makeGameState(deck: [aGameOfCards, landAhoy, aSenseOfPorpoise]);
+      state.discard.addAll([aRivalShip, krakenInMyBoots, shoallyYouCantBeSerious]);
+      state.currentCard = shoallyYouCantBeSerious;
+      state.scrying.add(shoallyYouCantBeSerious);
+
+      expect(state.getActiveQuestCards(), [shoallyYouCantBeSerious, krakenInMyBoots, aSenseOfPorpoise, landAhoy]);
     });
   });
 }

--- a/test/model/game_state_test.dart
+++ b/test/model/game_state_test.dart
@@ -257,7 +257,7 @@ void main() {
       final GameState state = makeGameState(deck: [aGameOfCards, landAhoy, aSenseOfPorpoise]);
       state.discard.addAll([aRivalShip, krakenInMyBoots, shoallyYouCantBeSerious]);
       state.currentCard = rumoursOfAnIsland;
-      state.scrying.addAll([utopia, aGameOfCards]);
+      state.scrying.addAll([utopia, aGameOfCards]); // shouldn't include quests from scrying
 
       final activeQuestCards = state.getActiveQuestCards();
       activeQuestCards.sort((card1, card2) => card1.name.compareTo(card2.name)); // sort so test doesn't care about order

--- a/test/model/game_state_test.dart
+++ b/test/model/game_state_test.dart
@@ -5,10 +5,12 @@ import 'package:treasure_of_the_high_seas/model/card/basic/a_game_of_cards.dart'
 import 'package:treasure_of_the_high_seas/model/card/basic/a_rival_ship.dart';
 import 'package:treasure_of_the_high_seas/model/card/basic/plunder_a_wreck.dart';
 import 'package:treasure_of_the_high_seas/model/card/basic/port_fees.dart';
+import 'package:treasure_of_the_high_seas/model/card/quest/hispaniola_1_rumours_of_an_island.dart';
 import 'package:treasure_of_the_high_seas/model/card/quest/hispaniola_2_land_ahoy.dart';
 import 'package:treasure_of_the_high_seas/model/card/quest/into_the_depths_1_a_sense_of_porpoise.dart';
 import 'package:treasure_of_the_high_seas/model/card/quest/into_the_depths_2_shoally_you_cant_be_serious.dart';
 import 'package:treasure_of_the_high_seas/model/card/quest/into_the_depths_3_kraken_in_my_boots.dart';
+import 'package:treasure_of_the_high_seas/model/card/quest/into_the_depths_4_utopia.dart';
 import 'package:treasure_of_the_high_seas/model/card/special/special_cards.dart';
 import 'package:treasure_of_the_high_seas/model/game_result.dart';
 import 'package:treasure_of_the_high_seas/model/game_state.dart';
@@ -240,21 +242,26 @@ void main() {
   });
 
   group('Getting active quests', () {
-    test('should return only quest cards from the deck and discard pile', () {
-      const aGameOfCards = AGameOfCards(); // basic card
-      const aRivalShip = ARivalShip(); // basic card
-      const landAhoy = LandAhoy(); // quest card
-      const aSenseOfPorpoise = ASenseOfPorpoise(); // quest card
-      const krakenInMyBoots = KrakenInMyBoots(); // quest card
-      const shoallyYouCantBeSerious = ShoallyYouCantBeSerious(); // quest card
+    test('should return only quest cards from the current card, deck and discard pile', () {
+      // basic cards:
+      const aGameOfCards = AGameOfCards();
+      const aRivalShip = ARivalShip();
+      // quest cards: (note we have at most 2 active quests in reality, but this makes the test stricter)
+      const rumoursOfAnIsland = RumoursOfAnIsland();
+      const landAhoy = LandAhoy();
+      const aSenseOfPorpoise = ASenseOfPorpoise();
+      const krakenInMyBoots = KrakenInMyBoots();
+      const shoallyYouCantBeSerious = ShoallyYouCantBeSerious();
+      const utopia = Utopia();
+
       final GameState state = makeGameState(deck: [aGameOfCards, landAhoy, aSenseOfPorpoise]);
       state.discard.addAll([aRivalShip, krakenInMyBoots, shoallyYouCantBeSerious]);
-      state.currentCard = shoallyYouCantBeSerious;
-      state.scrying.add(shoallyYouCantBeSerious);
+      state.currentCard = rumoursOfAnIsland;
+      state.scrying.addAll([utopia, aGameOfCards]);
 
       final activeQuestCards = state.getActiveQuestCards();
       activeQuestCards.sort((card1, card2) => card1.name.compareTo(card2.name)); // sort so test doesn't care about order
-      expect(activeQuestCards, [aSenseOfPorpoise, krakenInMyBoots, landAhoy, shoallyYouCantBeSerious]);
+      expect(activeQuestCards, [aSenseOfPorpoise, krakenInMyBoots, landAhoy, rumoursOfAnIsland, shoallyYouCantBeSerious]);
     });
   });
 }

--- a/test/model/game_state_test.dart
+++ b/test/model/game_state_test.dart
@@ -240,7 +240,7 @@ void main() {
   });
 
   group('Getting active quests', () {
-    test('should return only quest cards from the deck and discard pile in reverse order', () {
+    test('should return only quest cards from the deck and discard pile', () {
       const aGameOfCards = AGameOfCards(); // basic card
       const aRivalShip = ARivalShip(); // basic card
       const landAhoy = LandAhoy(); // quest card
@@ -252,7 +252,9 @@ void main() {
       state.currentCard = shoallyYouCantBeSerious;
       state.scrying.add(shoallyYouCantBeSerious);
 
-      expect(state.getActiveQuestCards(), [shoallyYouCantBeSerious, krakenInMyBoots, aSenseOfPorpoise, landAhoy]);
+      final activeQuestCards = state.getActiveQuestCards();
+      activeQuestCards.sort((card1, card2) => card1.name.compareTo(card2.name)); // sort so test doesn't care about order
+      expect(activeQuestCards, [aSenseOfPorpoise, krakenInMyBoots, landAhoy, shoallyYouCantBeSerious]);
     });
   });
 }

--- a/test/screens/play/view_active_quests_page_test.dart
+++ b/test/screens/play/view_active_quests_page_test.dart
@@ -10,11 +10,9 @@ void main() {
   testWidgets('close button should return to play page', (WidgetTester tester) async {
     final audioModel = MockAudioModel();
     await launchGameFromMenuMock(tester, audioModel: audioModel);
-
     await tester.pumpAndSettle();
 
     final activeQuestsFinder = find.byIcon(Icons.assignment);
-    expect(activeQuestsFinder, findsOneWidget);
     await tester.tap(activeQuestsFinder);
     await tester.pumpAndSettle();
 
@@ -22,10 +20,9 @@ void main() {
     expect(find.byType(PlayerHand), findsNothing);
 
     final exitFinder = find.text('Close');
-    expect(exitFinder, findsOneWidget);
-
     await tester.tap(exitFinder);
     await tester.pumpAndSettle();
+
     expect(find.byType(PlayerHand), findsOneWidget);
   });
 }

--- a/test/screens/play/view_active_quests_page_test.dart
+++ b/test/screens/play/view_active_quests_page_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:treasure_of_the_high_seas/screens/play/player_hand.dart';
+import 'package:treasure_of_the_high_seas/screens/play/view_active_quests_page.dart';
+
+import '../../mocks.dart';
+import '../../test_utils.dart';
+
+void main() {
+  testWidgets('close button should return to play page', (WidgetTester tester) async {
+    final audioModel = MockAudioModel();
+    await launchGameFromMenuMock(tester, audioModel: audioModel);
+
+    await tester.pumpAndSettle();
+
+    final activeQuestsFinder = find.byIcon(Icons.assignment);
+    expect(activeQuestsFinder, findsOneWidget);
+    await tester.tap(activeQuestsFinder);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(ViewActiveQuestsPage), findsOneWidget);
+    expect(find.byType(PlayerHand), findsNothing);
+
+    final exitFinder = find.text('Close');
+    expect(exitFinder, findsOneWidget);
+
+    await tester.tap(exitFinder);
+    await tester.pumpAndSettle();
+    expect(find.byType(PlayerHand), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Adds an "active quests" card view, linked from the play page via an icon next to the quick help and settings.

I would potentially also like to (potentially in a follow-up PR), and depending on opinions):
- add more tests - maybe this should be covered by card_view tests
- allow the card view to be amended to remove the "exile" and "discard" options which aren't relevant and can't be used in this context