### PR TITLE
Card viewer numbering

### DIFF
--- a/lib/screens/play/card_viewer.dart
+++ b/lib/screens/play/card_viewer.dart
@@ -14,8 +14,11 @@ class CardViewer extends StatelessWidget {
   Widget build(BuildContext context) {
     List<Widget> cardWidgetList = cardList.map((card) {
       final List<Widget> buttons = getButtons(context, card);
-      final List<Widget> columnComponents = [_getCardWidget(context, card), ...buttons];
-
+      final List<Widget> columnComponents = [
+        _buildCardNumberWidget(context, cardList, card),
+        _buildCardWidget(context, card),
+        ...buttons
+      ];
       return Container(
           width: MediaQuery.of(context).size.width,
           child: Column(mainAxisAlignment: MainAxisAlignment.center, children:
@@ -32,7 +35,7 @@ class CardViewer extends StatelessWidget {
         });
   }
 
-  Widget _getCardWidget(BuildContext context, Model.Card card) {
+  Widget _buildCardWidget(BuildContext context, Model.Card card) {
     return Container(
         padding: EdgeInsets.symmetric(vertical: 5),
         height: MediaQuery.of(context).size.height * 0.65,
@@ -40,6 +43,15 @@ class CardViewer extends StatelessWidget {
           card,
           readOnly: true,
         ));
+  }
+
+  Widget _buildCardNumberWidget(BuildContext context, List<Model.Card> cardList, Model.Card currentCard) {
+    final position = cardList.indexOf(currentCard) + 1;
+    return Container(
+        padding: EdgeInsets.symmetric(vertical: 5),
+        height: MediaQuery.of(context).size.height * 0.03,
+        child: Text("$position / ${cardList.length}")
+    );
   }
 
 }

--- a/test/screens/play/card_viewer_test.dart
+++ b/test/screens/play/card_viewer_test.dart
@@ -15,66 +15,106 @@ void main() {
   }
   final List<Model.Card> cardList = [AGameOfCards(), ARivalShip(), AnIsland()];
 
-  testWidgets('the first card in the list should be shown initially', (WidgetTester tester) async {
-    await tester.launchWidget(child: CardViewer(cardList, getButtons), state: makeGameState());
+  group('displaying cards should', () {
 
-    _expectOnlyCard(cardList.first.name, cardList);
+    testWidgets('show the first card in the list initially', (
+        WidgetTester tester) async {
+      await tester.launchWidget(
+          child: CardViewer(cardList, getButtons), state: makeGameState());
+
+      _expectOnlyCard(cardList.first.name, cardList);
+    });
+
+    testWidgets('show the second card in the list after tapping the right arrow', (
+        WidgetTester tester) async {
+      await tester.launchWidget(
+          child: CardViewer(cardList, getButtons), state: makeGameState());
+      final rightArrow = find.byIcon(Icons.arrow_forward_ios);
+
+      await tester.tap(rightArrow);
+      await tester.pumpAndSettle();
+
+      _expectOnlyCard(cardList
+          .elementAt(1)
+          .name, cardList);
+    });
+
+    testWidgets('loop around to show the first card after tapping the right arrow from the final card', (
+        WidgetTester tester) async {
+      await tester.launchWidget(
+          child: CardViewer(cardList, getButtons), state: makeGameState());
+      final rightArrow = find.byIcon(Icons.arrow_forward_ios);
+
+      await tester.tap(rightArrow);
+      await tester.pumpAndSettle();
+      await tester.tap(rightArrow);
+      await tester.pumpAndSettle();
+      await tester.tap(rightArrow);
+      await tester.pumpAndSettle();
+
+      _expectOnlyCard(cardList.first.name, cardList);
+    });
+
+    testWidgets('loop around to show the last card after tapping the left arrow from the first card', (
+        WidgetTester tester) async {
+      await tester.launchWidget(
+          child: CardViewer(cardList, getButtons), state: makeGameState());
+      final leftArrow = find.byIcon(Icons.arrow_back_ios);
+
+      await tester.tap(leftArrow);
+      await tester.pumpAndSettle();
+
+      _expectOnlyCard(cardList.last.name, cardList);
+    });
+
   });
 
-  testWidgets('tapping the right arrow should advance the selected card', (WidgetTester tester) async {
-    await tester.launchWidget(child: CardViewer(cardList, getButtons), state: makeGameState());
-    final rightArrow = find.byIcon(Icons.arrow_forward_ios);
+  group('displaying buttons should', () {
 
-    await tester.tap(rightArrow);
-    await tester.pumpAndSettle();
+    testWidgets('show the provided buttons on the page', (WidgetTester tester) async {
+      await tester.launchWidget(child: CardViewer(cardList, getButtons), state: makeGameState());
 
-    _expectOnlyCard(cardList.elementAt(1).name, cardList);
+      final button1Finder = find.text("${cardList.first.name} button 1");
+      final button2Finder = find.text("${cardList.first.name} button 2");
+      expect(button1Finder, findsOneWidget);
+      expect(button2Finder, findsOneWidget);
+    });
+
+    testWidgets('change the buttons depending on the card being viewed', (WidgetTester tester) async {
+      await tester.launchWidget(child: CardViewer(cardList, getButtons), state: makeGameState());
+      final rightArrow = find.byIcon(Icons.arrow_forward_ios);
+
+      await tester.tap(rightArrow);
+      await tester.pumpAndSettle();
+
+      final button1Finder = find.text("${cardList.elementAt(1).name} button 1");
+      final button2Finder = find.text("${cardList.elementAt(1).name} button 2");
+      expect(button1Finder, findsOneWidget);
+      expect(button2Finder, findsOneWidget);
+    });
+
   });
 
-  testWidgets('tapping the right arrow when at the last card should loop around to the first card', (WidgetTester tester) async {
-    await tester.launchWidget(child: CardViewer(cardList, getButtons), state: makeGameState());
-    final rightArrow = find.byIcon(Icons.arrow_forward_ios);
+  group('displaying the card numbering should', () {
 
-    await tester.tap(rightArrow);
-    await tester.pumpAndSettle();
-    await tester.tap(rightArrow);
-    await tester.pumpAndSettle();
-    await tester.tap(rightArrow);
-    await tester.pumpAndSettle();
+    testWidgets('show the position of the card currently being viewed in the list of cards', (WidgetTester tester) async {
+      await tester.launchWidget(child: CardViewer(cardList, getButtons), state: makeGameState());
 
-    _expectOnlyCard(cardList.first.name, cardList);
-  });
+      final cardNumberFinder = find.text("1 / ${cardList.length}");
+      expect(cardNumberFinder, findsOneWidget);
+    });
 
-  testWidgets('tapping the left arrow should loop around to the last card', (WidgetTester tester) async {
-    await tester.launchWidget(child: CardViewer(cardList, getButtons), state: makeGameState());
-    final leftArrow = find.byIcon(Icons.arrow_back_ios);
+    testWidgets('change the card number after changing the card being viewed', (WidgetTester tester) async {
+      await tester.launchWidget(child: CardViewer(cardList, getButtons), state: makeGameState());
+      final rightArrow = find.byIcon(Icons.arrow_forward_ios);
 
-    await tester.tap(leftArrow);
-    await tester.pumpAndSettle();
+      await tester.tap(rightArrow);
+      await tester.pumpAndSettle();
 
-    _expectOnlyCard(cardList.last.name, cardList);
-  });
+      final cardNumberFinder = find.text("2 / ${cardList.length}");
+      expect(cardNumberFinder, findsOneWidget);
+    });
 
-  testWidgets('the provided buttons should be rendered on the page', (WidgetTester tester) async {
-    await tester.launchWidget(child: CardViewer(cardList, getButtons), state: makeGameState());
-
-    final button1Finder = find.text("${cardList.first.name} button 1");
-    final button2Finder = find.text("${cardList.first.name} button 2");
-    expect(button1Finder, findsOneWidget);
-    expect(button2Finder, findsOneWidget);
-  });
-
-  testWidgets('the provided buttons should change depending on the card being viewed', (WidgetTester tester) async {
-    await tester.launchWidget(child: CardViewer(cardList, getButtons), state: makeGameState());
-    final rightArrow = find.byIcon(Icons.arrow_forward_ios);
-
-    await tester.tap(rightArrow);
-    await tester.pumpAndSettle();
-
-    final button1Finder = find.text("${cardList.elementAt(1).name} button 1");
-    final button2Finder = find.text("${cardList.elementAt(1).name} button 2");
-    expect(button1Finder, findsOneWidget);
-    expect(button2Finder, findsOneWidget);
   });
 
 }


### PR DESCRIPTION
Adds a card number widget to card viewer to indicate position of card in list of cards being viewed, e.g. 2 / 3 when viewing the second card in a list of three.

I attempted adding a test to assert that we show a message like "No cards to display" instead of a number in the case that there are zero cards, and then amending the logic in _buildCardNumberWidget to accomplish this, but it turns out that in the case of an empty card list, we don't include the card viewer at all because of the map

`List<Widget> cardWidgetList = cardList.map((card) {`

in CardViewer, inside which the CardViewer is constructed. Therefore, it doesn't show anything silly like "1 / 0" like I thought it might, so I have omitted these changes (the test doesn't pass anyway, because we don't render the CardViewer in isolation).